### PR TITLE
Add Card slice in cards paginated response

### DIFF
--- a/responses/cards.go
+++ b/responses/cards.go
@@ -231,10 +231,10 @@ func (r *CardListResponse) UnmarshalJSON(data []byte) (err error) {
 }
 
 type CardsPage struct {
-	*pagination.Page[Card]
+	*pagination.Page[[]Card]
 }
 
-func (r *CardsPage) Card() *Card {
+func (r *CardsPage) Cards() *[]Card {
 	return r.Current()
 }
 

--- a/services/cards.go
+++ b/services/cards.go
@@ -62,7 +62,7 @@ func (r *CardService) List(ctx context.Context, query *requests.CardListParams, 
 		return
 	}
 	res = &responses.CardsPage{
-		Page: &pagination.Page[responses.Card]{
+		Page: &pagination.Page[[]responses.Card]{
 			Config:  *cfg,
 			Options: opts,
 		},

--- a/tests/services/cards_test.go
+++ b/tests/services/cards_test.go
@@ -62,7 +62,7 @@ func TestCardsUpdateWithOptionalParams(t *testing.T) {
 
 func TestCardsListWithOptionalParams(t *testing.T) {
 	c := lithic.NewLithic(options.WithAPIKey("APIKey"), options.WithBaseURL("http://127.0.0.1:4010"))
-	_, err := c.Cards.List(context.TODO(), &requests.CardListParams{AccountToken: fields.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"), Begin: fields.F(time.Now()), End: fields.F(time.Now()), Page: fields.F(int64(0)), PageSize: fields.F(int64(1))})
+	res, err := c.Cards.List(context.TODO(), &requests.CardListParams{AccountToken: fields.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"), Begin: fields.F(time.Now()), End: fields.F(time.Now()), Page: fields.F(int64(0)), PageSize: fields.F(int64(1))})
 	if err != nil {
 		var apiError core.APIError
 		if errors.As(err, &apiError) {
@@ -70,6 +70,13 @@ func TestCardsListWithOptionalParams(t *testing.T) {
 			println(string(body))
 		}
 		t.Fatalf("err should be nil: %s", err.Error())
+	}
+
+	for res.Next() {
+		items := res.Current()
+		if items == nil || len(*items) == 0 {
+			t.Fatalf("there should be at least one item")
+		}
 	}
 }
 


### PR DESCRIPTION
The Cards paginated response from ListCards was only returning a single card. This change enables the service to return a page of card*S*

The changes includes an update to the cards_test test for Cards.List to check for the existence of at least one card in the slice,